### PR TITLE
Add responsive styles for footer & header

### DIFF
--- a/portalcodivasapp/src/Components/Footer.jsx
+++ b/portalcodivasapp/src/Components/Footer.jsx
@@ -4,14 +4,14 @@ import { Link } from "react-router-dom";
 function Footer(){
     const currentYear = new Date().getFullYear();
     return (
-    <footer>
-        <img src="codivaspreto.png" width={110} alt="" />
-        <p>© {currentYear} <Link to="/">Codivas</Link> </p>
-        <div>
-        <a href="#">Codivas</a>
-        <a href="#">Sobre Nos</a>
-        <a href="#">Blogs</a>
-        </div>
+    <footer className="footer">
+        <img src="logo.png" width={110} alt="" />
+        <span className="copyright">© {currentYear} <Link to="/">Codivas</Link> </span>
+        <ul className="footer-links">
+            <li>Codivas</li>
+            <li>Sobre Nos</li>
+            <li>Blogs</li>
+        </ul>
     </footer>
 );
     }

--- a/portalcodivasapp/src/sass/components/footer.scss
+++ b/portalcodivasapp/src/sass/components/footer.scss
@@ -1,34 +1,55 @@
-footer{
-    position: absolute;
-    padding-top: 10px;
+@use '../variables' as *;
+@use '../mixins' as *;
+
+.footer {
+    display:flex;
+    justify-content: space-between;
+    position: sticky;
     bottom: 0;
-    width: 100%;
-    height: 7rem;
-    background-color: rgb(255, 255, 255);
+    min-height: 144px;
+    background-color: white;
+    @include layoutShadow('up');
+    img {
+        position: absolute;
+        inset: 0;
+        margin: auto;
+        min-width: 180px;
+    }
 }
-footer img{
-    margin-left: 45%;
-    padding-top: 35px;
+.copyright {
+    padding: 1rem 0 1rem 1rem;
+    align-self: flex-end;
+    color: $color-font;
 }
-footer p{
-    position: absolute;
-    top: 85px;
-    margin-left: 2%;
-    font-size: 14px;
-    color: rgb(131, 133, 130);
-    font-weight: 600;
-}
+
 footer span{
     color: rgb(25, 125, 255);
 }
-footer div{
-    position: absolute;
-    top: 85px;
-    margin-left: 88%;
-    font-size: 14px;
-}
-footer div a{
-    color: rgb(131, 133, 130);
-    text-decoration: none;
-    padding-right: 5px;
+
+
+.footer-links {
+    height:100%;
+    display: flex;
+    align-items:flex-end;
+    padding: 1rem 1rem 1rem 0;
+    gap: .5rem;
+    li {
+        transition: $link-transition;
+        color: $color-font-lighter;
+        cursor: pointer;
+        &:hover {
+            color: $color-font;
+        }
+    }
+} 
+
+@media screen and (max-width:480px) {
+    .footer img {
+        margin: 0;
+        margin-right: auto;
+        padding: 1rem;
+    }
+    .footer-links {
+        flex-direction: column;
+    }
 }

--- a/portalcodivasapp/src/sass/components/header.scss
+++ b/portalcodivasapp/src/sass/components/header.scss
@@ -53,7 +53,6 @@
     color: $color-main;
     height: 100%;
     width: 100%;
-    grid-column: user;
     display: flex;
     align-items: center;
     min-width: fit-content;
@@ -61,6 +60,7 @@
     margin-left: auto;
     
     div {
+        transition: all 400ms ease;
         font-size: 2rem;
         margin: 0 1rem;
     }
@@ -87,11 +87,25 @@
     display: none;
 }
 
-@media (max-width:800px) {
+@media screen and (max-width:800px) {
     .search {
         display: none;
     }
     .hamburger-toggle {
         display: block;
+    }
+}
+
+@media screen and (max-width:480px) {
+    .user {
+        .profile .name {
+            display: none;
+        }
+    }
+}
+
+@media screen and (max-width:1024px) {
+    .user div{
+        margin: 0;
     }
 }


### PR DESCRIPTION
Issue #21 

- Add responsive styles for footer
- Fix some edge cases on smallish screens for header too
- Hides the username and lists the footer links in a column when under 480px screen width 
(still might be some slight overflow on usernames over 12 characters long in some screen sizes in between)