### PR TITLE
[FIX]: links in login and register page

### DIFF
--- a/src/Pages/Login.jsx
+++ b/src/Pages/Login.jsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import H2 from "./Home";
 import LoginHooks from "../hooks/LoginHooks";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 
 export const Forms =  styled.form`
   border-radius:0px 50px 0px 50px;
@@ -38,6 +39,7 @@ function Login() {
 						Esqueceu a senha?
 					</a>
 					<Input type="submit" name="" value="Login" />
+					<p className="mb-3">Não tem conta? <Link to="/registro" className="nav-link d-inline">Registe-se agora</Link></p>
 				</div>
 
 				<ul className="social-network social-circle d-flex mt-2 justify-content-around">

--- a/src/Pages/Register.jsx
+++ b/src/Pages/Register.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import RegisterHook from "../hooks/RegisterHook";
 import styled from "styled-components";
-
+import { Link } from "react-router-dom";
 export const Forms =  styled.div`
   border-radius:0px 50px 0px 50px;
   box-shadow: 10px 10px 10px 5px #080808;
@@ -41,6 +41,7 @@ function Register() {
                 <input type="password" name="password" placeholder="Password" required onChange={handlePassword} />
                 <Input type="submit" name="submit" value="Register" />
 				</div>
+        <p className="mb-3">Já tem uma conta? <Link to="/" className="nav-link d-inline">Login</Link></p>
 				<ul className="social-network social-circle d-flex mt-2 justify-content-around">
 					<li>
 						<a href="https://github.com/Codivas" className="icoGitHub" title="Github">


### PR DESCRIPTION
I have added the information and links which will make easy to navigate between login and register page.

## Screenshots
Login Page
<img width="730" alt="Screen Shot 2022-10-29 at 09 58 19" src="https://user-images.githubusercontent.com/59108522/198813358-eeefd2e8-5107-48b3-a883-38e84018d5f7.png">


Register Page
<img width="715" alt="Screen Shot 2022-10-29 at 09 58 29" src="https://user-images.githubusercontent.com/59108522/198813366-c80a2afb-3fba-4b2a-a584-529ecc84d324.png">

